### PR TITLE
update pg_perf_stat_snapper.py

### DIFF
--- a/Code/PGPerfStatsSnapper/pg_perf_stat_snapper.py
+++ b/Code/PGPerfStatsSnapper/pg_perf_stat_snapper.py
@@ -183,6 +183,9 @@ if __name__ == "__main__":
             
             drop_view_ddl=""
             
+            # Set client_encoding to UTF-8, this prevents possible character encoding errors
+            cur.execute("SET client_encoding=utf8")
+            
             if MODE == 'snap':
                 
                 # Create snapper running file to prevent concurrent script runs for same host and database combination


### PR DESCRIPTION
set client_encoding to UTF-8, this prevents possible character encoding errors

*Issue #, if available:*

*Description of changes:* 
This change corrects to avoid encoding errors when the database has client_encoding other than utf8.

Error example:
2020-08-24 20:23:41,590 - ERROR - Error While running query: select 1, * from pg_stat_all_indexes
2020-08-24 20:23:41,591 - ERROR - Exception: Internal error in 'copy (select 1, * from pg_stat_all_indexes) to stdout (format csv)': unknown encoding: WIN1252

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
